### PR TITLE
deps: remove racket/gui

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,6 @@
 (define deps
   '(
     "base"
-    "racket/gui"
     "gui-lib"
     "at-exp-lib"
     "htdp-lib"


### PR DESCRIPTION
Install gets confused with `racket/gui`—I'm pretty sure `gui-lib` is the right thing.